### PR TITLE
Set default parameters for IMU inference node

### DIFF
--- a/src/modules/mavlink/imu_listener.py
+++ b/src/modules/mavlink/imu_listener.py
@@ -4,15 +4,29 @@ import numpy as np
 import onnxruntime as ort
 import pickle
 import os
-import rospkg
 from sensor_msgs.msg import Imu
-from std_msgs.msg import Header
 import sys
+
+try:
+    from mavros_msgs.msg import HilSensor
+except ImportError:  # pragma: no cover - dependency optional for tests
+    HilSensor = None
 
 # --- configuration ---
 SEQLEN   = 50        # Number of IMU samples per inference window
 INTERVAL = 9          # Interval between inference windows
 OVERLAP  = INTERVAL + 1  # Number of samples kept between windows for overlap
+
+DEFAULT_IMU_TOPIC = "/mavros/imu/data"
+DEFAULT_CORRECTED_TOPIC = "/corrected_imu"
+DEFAULT_HIL_TOPIC = "/mavros/hil_sensor/imu"
+DEFAULT_ONNX_PATH = "/path/to/model.onnx"
+DEFAULT_RESULTS_PATH = "/tmp/imu_results.pkl"
+
+# HIL_SENSOR field bitmasks from mavlink_receiver.h
+HIL_SENSOR_ACCEL = 0b111
+HIL_SENSOR_GYRO  = 0b111000
+HIL_SENSOR_FIELDS = HIL_SENSOR_ACCEL | HIL_SENSOR_GYRO
 
 class IMUBuffer:
     """Buffer for storing IMU data and managing inference windows."""
@@ -54,16 +68,19 @@ class IMUBuffer:
         self.buf_idx = self.overlap
 
 class CorrectedIMUPublisher:
-    """Publishes corrected IMU messages to a ROS topic."""
-    def __init__(self, topic_name="/corrected_imu"):
-        self.pub = rospy.Publisher(topic_name, Imu, queue_size=100)
+    """Publishes corrected IMU messages and forwards them as HIL_SENSOR."""
 
-    def publish(self, corrected_acc, corrected_gyro):
+    def __init__(self, topic_name="/corrected_imu", hil_topic="/mavros/hil_sensor/imu"):
+        self.pub = rospy.Publisher(topic_name, Imu, queue_size=100)
+        self.hil_pub = rospy.Publisher(hil_topic, HilSensor, queue_size=10) if HilSensor else None
+
+    def publish(self, original_msg: Imu, corrected_acc, corrected_gyro):
+        """Publish corrected IMU data while preserving original header."""
         imu_msg = Imu()
 
-        # timestamp
-        imu_msg.header.stamp = rospy.Time.now()
-        imu_msg.header.frame_id = "imu_link"
+        # Propagate original timestamp and frame
+        imu_msg.header.stamp = original_msg.header.stamp
+        imu_msg.header.frame_id = original_msg.header.frame_id
 
         # Corrected acceleration
         imu_msg.linear_acceleration.x = float(corrected_acc[0])
@@ -75,20 +92,43 @@ class CorrectedIMUPublisher:
         imu_msg.angular_velocity.y = float(corrected_gyro[1])
         imu_msg.angular_velocity.z = float(corrected_gyro[2])
 
+        # Orientation not provided
+        imu_msg.orientation_covariance[0] = -1
+
+        # Example covariance values for corrected data
+        imu_msg.angular_velocity_covariance = [0.001, 0.0, 0.0,
+                                               0.0, 0.001, 0.0,
+                                               0.0, 0.0, 0.001]
+        imu_msg.linear_acceleration_covariance = [0.01, 0.0, 0.0,
+                                                   0.0, 0.01, 0.0,
+                                                   0.0, 0.0, 0.01]
+
         self.pub.publish(imu_msg)
+
+        if self.hil_pub is not None:
+            hil_msg = HilSensor()
+            hil_msg.header = imu_msg.header
+            hil_msg.xacc = imu_msg.linear_acceleration.x
+            hil_msg.yacc = imu_msg.linear_acceleration.y
+            hil_msg.zacc = imu_msg.linear_acceleration.z
+            hil_msg.xgyro = imu_msg.angular_velocity.x
+            hil_msg.ygyro = imu_msg.angular_velocity.y
+            hil_msg.zgyro = imu_msg.angular_velocity.z
+            hil_msg.fields_updated = HIL_SENSOR_FIELDS
+            self.hil_pub.publish(hil_msg)
 
 class IMUInferenceNode:
     """Main node for IMU inference and publishing corrected data."""
+
     def __init__(self):
-        rp = rospkg.RosPack()
-        self.pkg_path = rp.get_path("imu_listener_pkg")
-        self.onnx_path   = os.path.join(self.pkg_path, "models", "airimu_euroc.onnx")
-        self.pickle_path = os.path.join(self.pkg_path, "results", "timeit_sim_new_net_output.pickle")
         self.buffer = IMUBuffer(SEQLEN, OVERLAP)
         self.results = []
         self.correction_counter = 0
         self.onnx_model = None
-        self.corrected_imu_pub = CorrectedIMUPublisher("/corrected_imu")
+        self.corrected_imu_pub = None
+        self.onnx_path = ""
+        self.pickle_path = ""
+        self.last_msg = None
 
     def check_files(self):
         if not os.path.isfile(self.onnx_path):
@@ -142,9 +182,10 @@ class IMUInferenceNode:
             rospy.loginfo("-----------------------")
 
             # Publish the last corrected IMU message
-            self.corrected_imu_pub.publish(
-               corrected_acc[0, -1], corrected_gyro[0, -1]
-            )
+            if self.last_msg is not None:
+                self.corrected_imu_pub.publish(
+                    self.last_msg, corrected_acc[0, -1], corrected_gyro[0, -1]
+                )
 
             self.results.append({
                 "correction_acc":  corr_acc[0],
@@ -160,6 +201,7 @@ class IMUInferenceNode:
 
     def imu_callback(self, msg: Imu):
         self.buffer.add(msg)
+        self.last_msg = msg
         if self.buffer.ready():
             self.run_inference()
             self.buffer.slide_window()
@@ -169,14 +211,22 @@ class IMUInferenceNode:
         rospy.loginfo(f"[INIT] Node started at ROS time: {rospy.Time.now().to_sec():.2f}")
         rospy.loginfo(f"[INFO] Python version: {sys.version}")
 
+        self.onnx_path = rospy.get_param(
+            "~onnx_path",
+            rospy.get_param("~onnx_model_path", DEFAULT_ONNX_PATH),
+        )
+        self.pickle_path = rospy.get_param("~results_path", DEFAULT_RESULTS_PATH)
+        imu_topic = rospy.get_param("~imu_topic", DEFAULT_IMU_TOPIC)
+        corrected_topic = rospy.get_param("~corrected_topic", DEFAULT_CORRECTED_TOPIC)
+        hil_topic = rospy.get_param("~hil_topic", DEFAULT_HIL_TOPIC)
+        self.corrected_imu_pub = CorrectedIMUPublisher(corrected_topic, hil_topic)
+
         if not self.check_files():
             rospy.signal_shutdown("Required files missing.")
             return
 
         self.load_model()
-        rospy.Subscriber("/imu_data", Imu, self.imu_callback, queue_size=1000)
-        # rospy.Subscriber("/snappy_imu", Imu, self.imu_callback, queue_size=1000)
-        # rospy.Subscriber("mavros/imu/data", Imu, self.imu_callback, queue_size=1000)
+        rospy.Subscriber(imu_topic, Imu, self.imu_callback, queue_size=1000)
         rospy.spin()
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- make ONNX model and results paths configurable via ROS params with defaults for `/path/to/model.onnx` and `/tmp/imu_results.pkl`
- forward corrected IMU on `/mavros/hil_sensor/imu` using MAVROS HilSensor
- expose parameters for IMU topic and corrected output, defaulting to `/mavros/imu/data` and `/corrected_imu`

## Testing
- `python3 -m py_compile src/modules/mavlink/imu_listener.py`


------
https://chatgpt.com/codex/tasks/task_e_68c251aafde0832ca9a29c03382e2a27