### PR TITLE
Keep raw vehicle_imu subscription active when EKF2 uses AI source

### DIFF
--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -241,6 +241,9 @@ bool EKF2::multi_init(int imu, int mag)
 
        bool changed_instance = _vehicle_imu_sub.ChangeInstance(imu) && _magnetometer_sub.ChangeInstance(mag);
 
+       // keep a passive subscription to the raw IMU so simulators keep publishing even when the AI feed is selected
+       _vehicle_imu_keepalive_sub.ChangeInstance(imu);
+
        if (!_vehicle_imu_ai_sub.ChangeInstance(imu)) {
                PX4_DEBUG("vehicle_imu_ai[%d] not ready during init, will retry when advertised", imu);
        }
@@ -428,13 +431,16 @@ void EKF2::Run()
 			_callback_registered = false;
 		}
 
-		_imu_source = requested_source;
-		source_changed = true;
+               _imu_source = requested_source;
+               source_changed = true;
 
-		if (_imu_source == ImuSource::VehicleImuAi) {
-			_vehicle_imu_ai_switch_time = hrt_absolute_time();
-			_vehicle_imu_ai_last_update = 0;
-			_vehicle_imu_ai_available_logged = false;
+               if (_imu_source == ImuSource::VehicleImuAi) {
+                       // keep raw vehicle_imu subscribed to prevent upstream publishers from idling
+                       _vehicle_imu_keepalive_sub.ChangeInstance(_vehicle_imu_sub.get_instance());
+
+                       _vehicle_imu_ai_switch_time = hrt_absolute_time();
+                       _vehicle_imu_ai_last_update = 0;
+                       _vehicle_imu_ai_available_logged = false;
 			_vehicle_imu_ai_stale_warned = false;
 			_vehicle_imu_ai_retry_time = 0;
 

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -450,11 +450,16 @@ void EKF2::Run()
 		}
        }
 
-       if (_multi_mode && (_imu_source == ImuSource::VehicleImuAi)) {
-               while (_vehicle_imu_keepalive_sub.update(&_vehicle_imu_keepalive_sample)) {
-                       // drain raw vehicle_imu to keep simulator publishers active
-               }
-       }
+	if (_multi_mode && (_imu_source == ImuSource::VehicleImuAi)) {
+		while (_vehicle_imu_keepalive_sub.update(&_vehicle_imu_keepalive_sample)) {
+			// drain raw vehicle_imu to keep simulator publishers active
+		}
+
+		if (_callback_registered && (_vehicle_imu_ai_last_update == 0)) {
+			// continue running while the AI feed is silent so the keepalive drain stays active
+			ScheduleDelayed(20_ms);
+		}
+	}
 
        if (!_callback_registered) {
                _callback_registered = imuCallbackSubscription(_imu_source)->registerCallback();

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -425,11 +425,11 @@ void EKF2::Run()
 		_vehicle_imu_ai_stale_warned = false;
 	}
 
-	if (requested_source != _imu_source) {
-		if (_callback_registered) {
-			imuCallbackSubscription(_imu_source)->unregisterCallback();
-			_callback_registered = false;
-		}
+       if (requested_source != _imu_source) {
+               if (_callback_registered) {
+                       imuCallbackSubscription(_imu_source)->unregisterCallback();
+                       _callback_registered = false;
+               }
 
                _imu_source = requested_source;
                source_changed = true;
@@ -448,10 +448,16 @@ void EKF2::Run()
 			_vehicle_imu_ai_switch_time = 0;
 			_vehicle_imu_ai_last_update = 0;
 		}
-	}
+       }
 
-	if (!_callback_registered) {
-		_callback_registered = imuCallbackSubscription(_imu_source)->registerCallback();
+       if (_multi_mode && (_imu_source == ImuSource::VehicleImuAi)) {
+               while (_vehicle_imu_keepalive_sub.update(&_vehicle_imu_keepalive_sample)) {
+                       // drain raw vehicle_imu to keep simulator publishers active
+               }
+       }
+
+       if (!_callback_registered) {
+               _callback_registered = imuCallbackSubscription(_imu_source)->registerCallback();
 
 		if (!_callback_registered) {
 			ScheduleDelayed(10_ms);

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -268,6 +268,8 @@ private:
 
        uORB::SubscriptionCallbackWorkItem _sensor_combined_sub{this, ORB_ID(sensor_combined)};
        uORB::SubscriptionCallbackWorkItem _vehicle_imu_sub{this, ORB_ID(vehicle_imu)};
+       // keeps the raw vehicle_imu subscribed when the AI source is active
+       uORB::Subscription _vehicle_imu_keepalive_sub{ORB_ID(vehicle_imu)};
        uORB::SubscriptionCallbackWorkItem _vehicle_imu_ai_sub{this, ORB_ID(vehicle_imu_ai)};
 
 	uORB::SubscriptionMultiArray<distance_sensor_s> _distance_sensor_subs{ORB_ID::distance_sensor};

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -268,8 +268,9 @@ private:
 
        uORB::SubscriptionCallbackWorkItem _sensor_combined_sub{this, ORB_ID(sensor_combined)};
        uORB::SubscriptionCallbackWorkItem _vehicle_imu_sub{this, ORB_ID(vehicle_imu)};
-       // keeps the raw vehicle_imu subscribed when the AI source is active
+       // keeps the raw vehicle_imu subscribed and drained when the AI source is active
        uORB::Subscription _vehicle_imu_keepalive_sub{ORB_ID(vehicle_imu)};
+       vehicle_imu_s _vehicle_imu_keepalive_sample{};
        uORB::SubscriptionCallbackWorkItem _vehicle_imu_ai_sub{this, ORB_ID(vehicle_imu_ai)};
 
 	uORB::SubscriptionMultiArray<distance_sensor_s> _distance_sensor_subs{ORB_ID::distance_sensor};


### PR DESCRIPTION
## Summary
- add a passive vehicle_imu subscription so the raw IMU stream stays advertised when switching to vehicle_imu_ai
- ensure the keepalive subscription tracks the active IMU instance during AI source transitions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dde22a4c54832c89ce4a7804c2e04a