### PR TITLE
Improve EKF2 AI UDP bridge reliability

### DIFF
--- a/src/modules/ekf2/CMakeLists.txt
+++ b/src/modules/ekf2/CMakeLists.txt
@@ -72,12 +72,14 @@ px4_add_module(
 		EKF/terrain_estimator.cpp
 		EKF/utils.cpp
 		EKF/vel_pos_fusion.cpp
-		EKF/zero_velocity_update.cpp
+                EKF/zero_velocity_update.cpp
 
-		EKF2.cpp
-		EKF2.hpp
-		EKF2Selector.cpp
-		EKF2Selector.hpp
+                EKF2.cpp
+                EKF2.hpp
+                ekf2_imu_udp_bridge.cpp
+                ekf2_imu_udp_bridge.hpp
+                EKF2Selector.cpp
+                EKF2Selector.hpp
 
 	DEPENDS
 		geo

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -33,12 +33,6 @@
 
 #include "EKF2.hpp"
 
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <errno.h>
 
 using namespace time_literals;
 using math::constrain;
@@ -521,17 +515,22 @@ void EKF2::Run()
 		}
 
 		// If in AI mode (EKF2_IMU_SRC=1), try to receive processed IMU data from UDP listener
-		imuSample imu_to_use = imu_sample_new;
-		if (_param_ekf2_imu_src.get() == 1) {
-			imuSample received_imu = {};
-			if (ReceiveAiImuDataFromUdp(received_imu, now)) {
-				imu_to_use = received_imu;  // Use AI-processed IMU data
-				PX4_DEBUG("[EKF2 AI IMU] Using received AI-processed IMU data");
-			}
-		}
+                bool use_ai_mode = (_param_ekf2_imu_src.get() == 1);
+                const imuSample *imu_ptr = &imu_sample_new;
+                imuSample received_imu{};
 
-		// push imu data into estimator
-		_ekf.setIMUData(imu_to_use);
+                if (use_ai_mode) {
+                        if (ReceiveAiImuDataFromUdp(received_imu, now)) {
+                                imu_ptr = &received_imu;
+                                PX4_DEBUG("[EKF2 AI IMU] Using received AI-processed IMU data");
+                        } else {
+                                // Wait for valid AI data before updating the estimator
+                                return;
+                        }
+                }
+
+                // push imu data into estimator
+                _ekf.setIMUData(*imu_ptr);
 		PublishAttitude(now); // publish attitude immediately (uses quaternion from output predictor)
 
 		// integrate time to monitor time slippage
@@ -2219,290 +2218,22 @@ timestamps from the sensor topics.
 	return 0;
 }
 
-namespace {
-// Helper to receive AI IMU feedback from UDP listener on port 14568
-void recv_ekf2_imu_udp_feedback(int &rx_socket, struct sockaddr_in &rx_addr, uint32_t &msg_count, hrt_abstime &last_log_time,
-                                 const hrt_abstime &timestamp) {
-    // Initialize receiver socket if needed
-    if (rx_socket < 0) {
-        rx_socket = socket(AF_INET, SOCK_DGRAM, 0);
-        if (rx_socket < 0) {
-            PX4_ERR("[AI IMU RX] Socket creation failed");
-            return;
-        }
-        // Set non-blocking mode
-        int flags = fcntl(rx_socket, F_GETFL, 0);
-        fcntl(rx_socket, F_SETFL, flags | O_NONBLOCK);
-
-        // Set SO_REUSEADDR to allow reuse of port
-        int reuse = 1;
-        if (setsockopt(rx_socket, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) < 0) {
-            PX4_WARN("[AI IMU RX] setsockopt(SO_REUSEADDR) failed");
-        }
-
-        // Set large receive buffer to prevent packet loss
-        int recv_buf_size = 16 * 1024 * 1024;  // 16MB
-        if (setsockopt(rx_socket, SOL_SOCKET, SO_RCVBUF, &recv_buf_size, sizeof(recv_buf_size)) < 0) {
-            PX4_WARN("[AI IMU RX] setsockopt(SO_RCVBUF) failed");
-        }
-
-        memset(&rx_addr, 0, sizeof(rx_addr));
-        rx_addr.sin_family = AF_INET;
-        rx_addr.sin_port = htons(14568);
-        rx_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-
-        if (bind(rx_socket, (struct sockaddr *)&rx_addr, sizeof(rx_addr)) < 0) {
-            PX4_ERR("[AI IMU RX] Bind failed on port 14568 (already in use?)");
-            close(rx_socket);
-            rx_socket = -1;
-            return;
-        }
-        PX4_INFO("[AI IMU RX] Initialized: listening on 127.0.0.1:14568 for AI IMU feedback");
-        msg_count = 0;
-        last_log_time = timestamp;
-    }
-
-    // Drain all available packets in non-blocking mode (loop to avoid buildup)
-    struct __attribute__((packed)) {
-        uint64_t timestamp;
-        uint64_t timestamp_sample;
-        uint32_t accel_device_id;
-        uint32_t gyro_device_id;
-        float delta_angle[3];
-        float delta_velocity[3];
-        uint16_t delta_angle_dt;
-        uint16_t delta_velocity_dt;
-        uint8_t delta_velocity_clipping;
-        uint8_t accel_calibration_count;
-        uint8_t gyro_calibration_count;
-    } imu_feedback;
-    uint8_t buf[55] = {};
-    struct sockaddr_in src_addr{};
-    socklen_t src_len = sizeof(src_addr);
-
-    // Loop to drain all available packets instead of processing just one
-    int packets_received_this_cycle = 0;
-    while (packets_received_this_cycle < 50) {  // Safety limit: max 50 packets per call
-        ssize_t n = recvfrom(rx_socket, buf, 55, 0, (struct sockaddr *)&src_addr, &src_len);
-        if (n == 55) {
-            memcpy(&imu_feedback, buf, sizeof(imu_feedback));
-            msg_count++;
-            packets_received_this_cycle++;
-
-            // Log first packet received
-            if (msg_count == 1) {
-                PX4_INFO("[STARTUP] EKF2 RX: First packet received | ts=%llu us ([%.1f ms])",
-                         (unsigned long long)imu_feedback.timestamp, (double)(imu_feedback.timestamp / 1000.0));
-            }
-
-            // Log every 5000 packets received (not based on wall-clock time)
-            if (msg_count % 5000 == 0) {
-                double packet_time_ms = (imu_feedback.timestamp / 1000.0);  // Convert us to ms
-                PX4_INFO("[%.1f ms] EKF2 RX=%u packets | accel_id=0x%x | dt_v=%u us",
-                         packet_time_ms, msg_count, imu_feedback.accel_device_id, imu_feedback.delta_velocity_dt);
-            }
-        } else {
-            // No more packets available (non-blocking recv returned EAGAIN/EWOULDBLOCK)
-            break;
-        }
-    }
-}
-
-// Helper for modular UDP IMU telemetry sender
-void send_ekf2_imu_udp_packet(int &udp_socket, sockaddr_in &udp_addr, uint32_t &msg_count, hrt_abstime &last_log_time,
-                              const imuSample &imu, const hrt_abstime &timestamp,
-                              uint32_t accel_device_id, uint32_t gyro_device_id,
-                              uint8_t accel_cal_count, uint8_t gyro_cal_count) {
-    // Initialize socket if needed
-    if (udp_socket < 0) {
-        udp_socket = socket(AF_INET, SOCK_DGRAM, 0);
-        if (udp_socket < 0) {
-            PX4_ERR("[IMU UDP] Socket creation failed");
-            return;
-        }
-        int flags = fcntl(udp_socket, F_GETFL, 0);
-        fcntl(udp_socket, F_SETFL, flags | O_NONBLOCK);
-        memset(&udp_addr, 0, sizeof(udp_addr));
-        udp_addr.sin_family = AF_INET;
-        udp_addr.sin_port = htons(14567);
-        udp_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-        PX4_INFO("[IMU UDP] Initialized: sending EKF2 IMU data to 127.0.0.1:14567");
-        msg_count = 0;
-        last_log_time = timestamp;
-    }
-    struct __attribute__((packed)) {
-        uint64_t timestamp;
-        uint64_t timestamp_sample;
-        uint32_t accel_device_id;
-        uint32_t gyro_device_id;
-        float delta_angle[3];
-        float delta_velocity[3];
-        uint16_t delta_angle_dt;
-        uint16_t delta_velocity_dt;
-        uint8_t delta_velocity_clipping;
-        uint8_t accel_calibration_count;
-        uint8_t gyro_calibration_count;
-    } imu_packet;
-    imu_packet.timestamp = imu.time_us;
-    imu_packet.timestamp_sample = imu.time_us;
-    imu_packet.accel_device_id = accel_device_id;
-    imu_packet.gyro_device_id = gyro_device_id;
-    memcpy(imu_packet.delta_angle, &imu.delta_ang, sizeof(imu.delta_ang));
-    memcpy(imu_packet.delta_velocity, &imu.delta_vel, sizeof(imu.delta_vel));
-    imu_packet.delta_angle_dt = (uint16_t)(imu.delta_ang_dt * 1e6f);
-    imu_packet.delta_velocity_dt = (uint16_t)(imu.delta_vel_dt * 1e6f);
-    imu_packet.delta_velocity_clipping = imu.delta_vel_clipping[0] | imu.delta_vel_clipping[1] | imu.delta_vel_clipping[2];
-    imu_packet.accel_calibration_count = accel_cal_count;
-    imu_packet.gyro_calibration_count = gyro_cal_count;
-    ssize_t bytes_sent = sendto(udp_socket, &imu_packet, sizeof(imu_packet), 0,
-                                (struct sockaddr *)&udp_addr, sizeof(udp_addr));
-    (void)bytes_sent;
-    msg_count++;
-
-    // Log first packet sent
-    if (msg_count == 1) {
-        PX4_INFO("[STARTUP] EKF2 TX: First packet sent at [%.1f ms] | ts=%llu us",
-                 (double)(imu_packet.timestamp / 1000.0), (unsigned long long)imu_packet.timestamp);
-    }
-
-    // Log every 5000 packets sent (packet-count based, not wall-clock)
-    if (msg_count % 5000 == 0) {
-        double packet_time_ms = (imu_packet.timestamp / 1000.0);  // Convert us to ms
-        PX4_INFO("[%.1f ms] EKF2 TX=%u packets | dv=[%.4f,%.4f,%.4f] m/s | da=[%.4f,%.4f,%.4f] rad | dt_v=%u us",
-            packet_time_ms,
-            msg_count,
-            (double)imu.delta_vel(0), (double)imu.delta_vel(1), (double)imu.delta_vel(2),
-            (double)imu.delta_ang(0), (double)imu.delta_ang(1), (double)imu.delta_ang(2),
-            imu_packet.delta_velocity_dt);
-    }
-}
-} // namespace
 
 // Receive and parse 55-byte AI IMU data from UDP listener on port 14568
 bool EKF2::ReceiveAiImuDataFromUdp(imuSample &imu, const hrt_abstime &timestamp)
 {
-    // Initialize receiver socket if needed
-    if (_imu_rx_socket < 0) {
-        _imu_rx_socket = socket(AF_INET, SOCK_DGRAM, 0);
-        if (_imu_rx_socket < 0) {
-            PX4_ERR("[AI IMU RX] Socket creation failed");
-            return false;
-        }
-        // Set non-blocking mode
-        int flags = fcntl(_imu_rx_socket, F_GETFL, 0);
-        fcntl(_imu_rx_socket, F_SETFL, flags | O_NONBLOCK);
+    const bool ai_mode_active = (_param_ekf2_imu_src.get() == 1);
 
-        // Set SO_REUSEADDR to allow reuse of port
-        int reuse = 1;
-        if (setsockopt(_imu_rx_socket, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) < 0) {
-            PX4_WARN("[AI IMU RX] setsockopt(SO_REUSEADDR) failed");
-        }
-
-        // Increase socket receive buffer to avoid packet loss
-        int recv_buf_size = 16 * 1024 * 1024;  // 16MB
-        if (setsockopt(_imu_rx_socket, SOL_SOCKET, SO_RCVBUF, &recv_buf_size, sizeof(recv_buf_size)) < 0) {
-            PX4_WARN("[AI IMU RX] setsockopt(SO_RCVBUF) failed");
-        }
-
-        // Bind to port 14568 to receive data from listener
-        memset(&_imu_rx_addr, 0, sizeof(_imu_rx_addr));
-        _imu_rx_addr.sin_family = AF_INET;
-        _imu_rx_addr.sin_port = htons(14568);
-        _imu_rx_addr.sin_addr.s_addr = htonl(INADDR_ANY);  // Listen on any interface
-
-        if (bind(_imu_rx_socket, (struct sockaddr *)&_imu_rx_addr, sizeof(_imu_rx_addr)) < 0) {
-            PX4_ERR("[AI IMU RX] Bind failed on port 14568: %s", strerror(errno));
-            close(_imu_rx_socket);
-            _imu_rx_socket = -1;
-            return false;
-        }
-        PX4_INFO("[AI IMU RX] Initialized: listening on 0.0.0.0:14568 for AI-processed IMU data");
-        _imu_rx_msg_count = 0;
-        _imu_rx_last_log_time = timestamp;
-    }
-
-    // Try to receive 55-byte AI IMU packet
-    struct __attribute__((packed)) {
-        uint64_t timestamp;
-        uint64_t timestamp_sample;
-        uint32_t accel_device_id;
-        uint32_t gyro_device_id;
-        float delta_angle[3];
-        float delta_velocity[3];
-        uint16_t delta_angle_dt;
-        uint16_t delta_velocity_dt;
-        uint8_t delta_velocity_clipping;
-        uint8_t accel_calibration_count;
-        uint8_t gyro_calibration_count;
-    } ai_imu_packet;
-
-    uint8_t buf[55] = {};
-    struct sockaddr_in src_addr{};
-    socklen_t src_len = sizeof(src_addr);
-    ssize_t n = recvfrom(_imu_rx_socket, buf, sizeof(buf), 0, (struct sockaddr *)&src_addr, &src_len);
-
-    if (n == 55) {
-        memcpy(&ai_imu_packet, buf, sizeof(ai_imu_packet));
-        _imu_rx_msg_count++;
-
-        // Log on first successful RX
-        if (_imu_rx_msg_count == 1) {
-            PX4_INFO("[AI IMU RX] ===== FIRST PACKET RECEIVED ===== | count=%u | ts=%lu us | dv=[%.4f,%.4f,%.4f]",
-                _imu_rx_msg_count, (unsigned long)ai_imu_packet.timestamp_sample,
-                (double)ai_imu_packet.delta_velocity[0], (double)ai_imu_packet.delta_velocity[1], (double)ai_imu_packet.delta_velocity[2]);
-        }
-
-        // Convert received packet to imuSample
-        imu.time_us = ai_imu_packet.timestamp_sample;
-        imu.delta_ang_dt = ai_imu_packet.delta_angle_dt * 1e-6f;
-        imu.delta_ang = Vector3f{ai_imu_packet.delta_angle[0], ai_imu_packet.delta_angle[1], ai_imu_packet.delta_angle[2]};
-        imu.delta_vel_dt = ai_imu_packet.delta_velocity_dt * 1e-6f;
-        imu.delta_vel = Vector3f{ai_imu_packet.delta_velocity[0], ai_imu_packet.delta_velocity[1], ai_imu_packet.delta_velocity[2]};
-
-        imu.delta_vel_clipping[0] = ai_imu_packet.delta_velocity_clipping & 0x01;
-        imu.delta_vel_clipping[1] = (ai_imu_packet.delta_velocity_clipping >> 1) & 0x01;
-        imu.delta_vel_clipping[2] = (ai_imu_packet.delta_velocity_clipping >> 2) & 0x01;
-
-        // Log periodically
-        if ((timestamp - _imu_rx_last_log_time) > 5_s) {
-            PX4_INFO("[AI IMU RX] Received %u packets | last: ts=%lu us, dv=[%.4f,%.4f,%.4f] m/s, da=[%.4f,%.4f,%.4f] rad",
-                _imu_rx_msg_count, (unsigned long)ai_imu_packet.timestamp_sample,
-                (double)ai_imu_packet.delta_velocity[0], (double)ai_imu_packet.delta_velocity[1], (double)ai_imu_packet.delta_velocity[2],
-                (double)ai_imu_packet.delta_angle[0], (double)ai_imu_packet.delta_angle[1], (double)ai_imu_packet.delta_angle[2]);
-            _imu_rx_last_log_time = timestamp;
-        }
-
-        return true;
-    } else if (n > 0 && n != 55) {
-        PX4_WARN("[AI IMU RX] Got %zd bytes (expected 55)", n);
-    } else if (n < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
-        PX4_ERR("[AI IMU RX] recvfrom error: %s", strerror(errno));
-    }
-
-    return false;
+    return ekf2::udp::ConsumeAiSample(_imu_udp_bridge, ai_mode_active, imu, timestamp);
 }
 
 void EKF2::PublishImuSampleToUdp(const imuSample &imu, const hrt_abstime &timestamp)
 {
-    // Only send if EKF2_IMU_SRC=1 (AI mode)
-    if (_param_ekf2_imu_src.get() != 1) {
-        // Close sockets if they were open but mode changed
-        if (_imu_udp_socket >= 0) {
-            close(_imu_udp_socket);
-            _imu_udp_socket = -1;
-        }
-        if (_imu_rx_socket >= 0) {
-            close(_imu_rx_socket);
-            _imu_rx_socket = -1;
-            PX4_INFO("[IMU UDP] Closed: EKF2_IMU_SRC changed from 1");
-        }
-        return;
-    }
-    // Call modular UDP sender
-    send_ekf2_imu_udp_packet(_imu_udp_socket, _imu_udp_addr, _imu_udp_msg_count, _imu_udp_last_log_time,
-                             imu, timestamp, _device_id_accel, _device_id_gyro, _accel_calibration_count, _gyro_calibration_count);
-    // Call modular UDP receiver for feedback
-    recv_ekf2_imu_udp_feedback(_imu_rx_socket, _imu_rx_addr, _imu_rx_msg_count, _imu_rx_last_log_time, timestamp);
+    const bool ai_mode_active = (_param_ekf2_imu_src.get() == 1);
+
+    ekf2::udp::PublishImuSample(_imu_udp_bridge, ai_mode_active, imu, timestamp,
+                                _device_id_accel, _device_id_gyro,
+                                _accel_calibration_count, _gyro_calibration_count);
 }
 
 extern "C" __EXPORT int ekf2_main(int argc, char *argv[])

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -193,12 +193,8 @@ EKF2::~EKF2()
 	perf_free(_msg_missed_magnetometer_perf);
 	perf_free(_msg_missed_odometry_perf);
 	perf_free(_msg_missed_optical_flow_perf);
-
-	// Clean up UDP socket
-	if (_imu_udp_socket >= 0) {
-		close(_imu_udp_socket);
-		_imu_udp_socket = -1;
-	}
+	// Ensure UDP bridge resources are released
+	_imu_udp_bridge.reset();
 }
 
 bool EKF2::multi_init(int imu, int mag)

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -45,10 +45,10 @@
 #include "Utility/PreFlightChecker.hpp"
 
 #include "EKF2Selector.hpp"
+#include "ekf2_imu_udp_bridge.hpp"
 
 #include <float.h>
 #include <sys/socket.h>
-#include <netinet/in.h>
 #include <arpa/inet.h>
 #include <fcntl.h>
 #include <unistd.h>
@@ -282,17 +282,7 @@ private:
 
 	hrt_abstime _last_update_time{}; // Tracks the last time vehicle_imu_ai was polled
 
-	// UDP telemetry for AI mode monitoring (port 14567 TX, 14568 RX)
-	int _imu_udp_socket{-1};
-	struct sockaddr_in _imu_udp_addr{};
-	uint32_t _imu_udp_msg_count{0};
-	hrt_abstime _imu_udp_last_log_time{0};
-
-	// UDP receiver for AI IMU feedback from listener (port 14568)
-	int _imu_rx_socket{-1};
-	struct sockaddr_in _imu_rx_addr{};
-	uint32_t _imu_rx_msg_count{0};
-	hrt_abstime _imu_rx_last_log_time{0};
+        ekf2::udp::ImuUdpBridgeState _imu_udp_bridge{};
 
 	hrt_abstime _last_event_flags_publish{0};
 	hrt_abstime _last_status_flags_publish{0};

--- a/src/modules/ekf2/ekf2_imu_udp_bridge.cpp
+++ b/src/modules/ekf2/ekf2_imu_udp_bridge.cpp
@@ -1,0 +1,368 @@
+#include "ekf2_imu_udp_bridge.hpp"
+
+#include <arpa/inet.h>
+#include <cerrno>
+#include <cstring>
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <px4_platform_common/log.h>
+
+#include <matrix/math.hpp>
+
+namespace ekf2::udp
+{
+namespace
+{
+constexpr size_t kPacketSize = 55;
+constexpr size_t kMaxQueueDepth = 512;
+constexpr unsigned kMaxDrainPerCycle = 256;
+constexpr hrt_abstime kLogInterval = 5_s;
+constexpr hrt_abstime kWarningInterval = 1_s;
+
+struct __attribute__((packed)) ImuPacket {
+    uint64_t timestamp;
+    uint64_t timestamp_sample;
+    uint32_t accel_device_id;
+    uint32_t gyro_device_id;
+    float delta_angle[3];
+    float delta_velocity[3];
+    uint16_t delta_angle_dt;
+    uint16_t delta_velocity_dt;
+    uint8_t delta_velocity_clipping;
+    uint8_t accel_calibration_count;
+    uint8_t gyro_calibration_count;
+};
+
+void close_socket(int &fd)
+{
+    if (fd >= 0) {
+        close(fd);
+        fd = -1;
+    }
+}
+
+void prepare_socket_common(int fd)
+{
+    int flags = fcntl(fd, F_GETFL, 0);
+    fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+
+    int reuse = 1;
+    if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) < 0) {
+        PX4_WARN("[IMU UDP] setsockopt(SO_REUSEADDR) failed: %s", strerror(errno));
+    }
+
+    int buf = 16 * 1024 * 1024;
+    if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &buf, sizeof(buf)) < 0) {
+        PX4_WARN("[IMU UDP] setsockopt(SO_RCVBUF) failed: %s", strerror(errno));
+    }
+    if (setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &buf, sizeof(buf)) < 0) {
+        PX4_WARN("[IMU UDP] setsockopt(SO_SNDBUF) failed: %s", strerror(errno));
+    }
+}
+
+bool ensure_tx_socket(ImuUdpBridgeState &state, hrt_abstime timestamp)
+{
+    if (state.tx_socket >= 0) {
+        return true;
+    }
+
+    state.tx_socket = socket(AF_INET, SOCK_DGRAM, 0);
+
+    if (state.tx_socket < 0) {
+        PX4_ERR("[IMU UDP TX] socket() failed: %s", strerror(errno));
+        return false;
+    }
+
+    prepare_socket_common(state.tx_socket);
+
+    memset(&state.tx_addr, 0, sizeof(state.tx_addr));
+    state.tx_addr.sin_family = AF_INET;
+    state.tx_addr.sin_port = htons(14567);
+    state.tx_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+    state.tx_count = 0;
+    state.tx_last_log = timestamp;
+    PX4_INFO("[IMU UDP TX] Initialized: sending EKF2 IMU data to 127.0.0.1:14567");
+    return true;
+}
+
+bool ensure_rx_socket(ImuUdpBridgeState &state, hrt_abstime timestamp)
+{
+    if (state.rx_socket >= 0) {
+        return true;
+    }
+
+    state.rx_socket = socket(AF_INET, SOCK_DGRAM, 0);
+
+    if (state.rx_socket < 0) {
+        PX4_ERR("[IMU UDP RX] socket() failed: %s", strerror(errno));
+        return false;
+    }
+
+    prepare_socket_common(state.rx_socket);
+
+    memset(&state.rx_addr, 0, sizeof(state.rx_addr));
+    state.rx_addr.sin_family = AF_INET;
+    state.rx_addr.sin_port = htons(14568);
+    state.rx_addr.sin_addr.s_addr = htonl(INADDR_ANY);
+
+    if (bind(state.rx_socket, reinterpret_cast<sockaddr *>(&state.rx_addr), sizeof(state.rx_addr)) < 0) {
+        PX4_ERR("[IMU UDP RX] bind() failed on port 14568: %s", strerror(errno));
+        close_socket(state.rx_socket);
+        return false;
+    }
+
+    state.rx_count = 0;
+    state.rx_last_log = timestamp;
+    state.rx_last_warning_log = 0;
+    state.last_rx_timestamp_sample = 0;
+
+    PX4_INFO("[IMU UDP RX] Initialized: listening for AI IMU feedback on 0.0.0.0:14568");
+    return true;
+}
+
+uint8_t clipping_mask(const imuSample &imu)
+{
+    uint8_t mask = 0;
+    mask |= (imu.delta_vel_clipping[0] ? 0x01 : 0);
+    mask |= (imu.delta_vel_clipping[1] ? 0x02 : 0);
+    mask |= (imu.delta_vel_clipping[2] ? 0x04 : 0);
+    return mask;
+}
+
+imuSample packet_to_sample(const ImuPacket &packet)
+{
+    imuSample sample{};
+    sample.time_us = packet.timestamp_sample;
+    sample.delta_ang_dt = packet.delta_angle_dt * 1e-6f;
+    sample.delta_ang = matrix::Vector3f{packet.delta_angle[0], packet.delta_angle[1], packet.delta_angle[2]};
+    sample.delta_vel_dt = packet.delta_velocity_dt * 1e-6f;
+    sample.delta_vel = matrix::Vector3f{packet.delta_velocity[0], packet.delta_velocity[1], packet.delta_velocity[2]};
+    sample.delta_vel_clipping[0] = packet.delta_velocity_clipping & 0x01;
+    sample.delta_vel_clipping[1] = (packet.delta_velocity_clipping >> 1) & 0x01;
+    sample.delta_vel_clipping[2] = (packet.delta_velocity_clipping >> 2) & 0x01;
+    return sample;
+}
+
+ImuPacket sample_to_packet(const imuSample &imu, uint32_t accel_device_id, uint32_t gyro_device_id,
+                           uint8_t accel_calibration_count, uint8_t gyro_calibration_count)
+{
+    ImuPacket packet{};
+    packet.timestamp = imu.time_us;
+    packet.timestamp_sample = imu.time_us;
+    packet.accel_device_id = accel_device_id;
+    packet.gyro_device_id = gyro_device_id;
+
+    memcpy(packet.delta_angle, imu.delta_ang.data(), sizeof(packet.delta_angle));
+    memcpy(packet.delta_velocity, imu.delta_vel.data(), sizeof(packet.delta_velocity));
+
+    packet.delta_angle_dt = static_cast<uint16_t>(imu.delta_ang_dt * 1e6f);
+    packet.delta_velocity_dt = static_cast<uint16_t>(imu.delta_vel_dt * 1e6f);
+    packet.delta_velocity_clipping = clipping_mask(imu);
+    packet.accel_calibration_count = accel_calibration_count;
+    packet.gyro_calibration_count = gyro_calibration_count;
+    return packet;
+}
+
+void flush_tx_queue(ImuUdpBridgeState &state, hrt_abstime timestamp)
+{
+    while (!state.tx_queue.empty() && state.tx_socket >= 0) {
+        const auto &buffer = state.tx_queue.front();
+        ssize_t sent = sendto(state.tx_socket, buffer.data(), buffer.size(), 0,
+                              reinterpret_cast<const sockaddr *>(&state.tx_addr), sizeof(state.tx_addr));
+
+        if (sent == static_cast<ssize_t>(buffer.size())) {
+            state.tx_queue.pop_front();
+            ++state.tx_count;
+
+            if (state.tx_count == 1) {
+                PX4_INFO("[IMU UDP TX] First packet sent at %.1f ms", static_cast<double>(timestamp) / 1000.0);
+            } else if ((timestamp - state.tx_last_log) > kLogInterval) {
+                PX4_INFO("[IMU UDP TX] Sent %u packets | queue depth=%zu", state.tx_count,
+                         static_cast<size_t>(state.tx_queue.size()));
+                state.tx_last_log = timestamp;
+            }
+
+        } else if (sent < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+            break;
+        } else {
+            if ((timestamp - state.tx_last_error_log) > kWarningInterval) {
+                PX4_WARN("[IMU UDP TX] sendto() failed: %s", strerror(errno));
+                state.tx_last_error_log = timestamp;
+            }
+            break;
+        }
+    }
+}
+
+void drain_rx_socket(ImuUdpBridgeState &state, hrt_abstime timestamp)
+{
+    if (state.rx_socket < 0) {
+        return;
+    }
+
+    ImuPacket packet{};
+    sockaddr_in src{};
+    socklen_t src_len = sizeof(src);
+    unsigned drained = 0;
+
+    while (drained < kMaxDrainPerCycle) {
+        ssize_t n = recvfrom(state.rx_socket, &packet, sizeof(packet), 0,
+                             reinterpret_cast<sockaddr *>(&src), &src_len);
+
+        if (n == static_cast<ssize_t>(sizeof(packet))) {
+            if (state.rx_queue.size() >= kMaxQueueDepth) {
+                state.rx_queue.pop_front();
+                if ((timestamp - state.rx_last_warning_log) > kWarningInterval) {
+                    PX4_WARN("[IMU UDP RX] Queue full, dropping oldest packet");
+                    state.rx_last_warning_log = timestamp;
+                }
+            }
+
+            state.rx_queue.emplace_back();
+            memcpy(state.rx_queue.back().data(), &packet, sizeof(packet));
+            ++state.rx_count;
+
+            if (state.rx_count == 1) {
+                PX4_INFO("[IMU UDP RX] First packet received | ts=%llu us", (unsigned long long)packet.timestamp_sample);
+            } else if ((timestamp - state.rx_last_log) > kLogInterval) {
+                PX4_INFO("[IMU UDP RX] Received %u packets | queue depth=%zu", state.rx_count,
+                         static_cast<size_t>(state.rx_queue.size()));
+                state.rx_last_log = timestamp;
+            }
+
+            if (state.last_rx_timestamp_sample > 0 && packet.timestamp_sample <= state.last_rx_timestamp_sample) {
+                if ((timestamp - state.rx_last_warning_log) > kWarningInterval) {
+                    PX4_WARN("[IMU UDP RX] Non-monotonic timestamp received (%llu <= %llu)",
+                             (unsigned long long)packet.timestamp_sample,
+                             (unsigned long long)state.last_rx_timestamp_sample);
+                    state.rx_last_warning_log = timestamp;
+                }
+            }
+
+            state.last_rx_timestamp_sample = packet.timestamp_sample;
+            ++drained;
+
+        } else if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+            break;
+        } else if (n < 0) {
+            if ((timestamp - state.rx_last_warning_log) > kWarningInterval) {
+                PX4_WARN("[IMU UDP RX] recvfrom() failed: %s", strerror(errno));
+                state.rx_last_warning_log = timestamp;
+            }
+            break;
+        } else if (n == 0) {
+            break;
+        } else {
+            if ((timestamp - state.rx_last_warning_log) > kWarningInterval) {
+                PX4_WARN("[IMU UDP RX] Unexpected packet size %zd", n);
+                state.rx_last_warning_log = timestamp;
+            }
+        }
+    }
+}
+
+} // namespace
+
+ImuUdpBridgeState::~ImuUdpBridgeState()
+{
+    reset();
+}
+
+void ImuUdpBridgeState::reset()
+{
+    close_socket(tx_socket);
+    close_socket(rx_socket);
+    tx_queue.clear();
+    rx_queue.clear();
+    last_ai_sample_valid = false;
+    tx_count = 0;
+    rx_count = 0;
+    tx_last_log = 0;
+    rx_last_log = 0;
+    tx_last_error_log = 0;
+    rx_last_warning_log = 0;
+    last_rx_timestamp_sample = 0;
+}
+
+bool PublishImuSample(ImuUdpBridgeState &state, bool ai_mode_active, const imuSample &imu,
+                      hrt_abstime timestamp, uint32_t accel_device_id, uint32_t gyro_device_id,
+                      uint8_t accel_calibration_count, uint8_t gyro_calibration_count)
+{
+    if (!ai_mode_active) {
+        // Keep raw data subscription alive but close UDP resources when not needed.
+        state.reset();
+        return false;
+    }
+
+    if (!ensure_tx_socket(state, timestamp)) {
+        return false;
+    }
+
+    ImuPacket packet = sample_to_packet(imu, accel_device_id, gyro_device_id,
+                                        accel_calibration_count, gyro_calibration_count);
+
+    std::array<uint8_t, kPacketSize> buffer{};
+    memcpy(buffer.data(), &packet, sizeof(packet));
+
+    if (state.tx_queue.size() >= kMaxQueueDepth) {
+        state.tx_queue.pop_front();
+        if ((timestamp - state.tx_last_error_log) > kWarningInterval) {
+            PX4_WARN("[IMU UDP TX] Queue full, dropping oldest packet");
+            state.tx_last_error_log = timestamp;
+        }
+    }
+
+    state.tx_queue.push_back(buffer);
+    flush_tx_queue(state, timestamp);
+    return true;
+}
+
+bool ConsumeAiSample(ImuUdpBridgeState &state, bool ai_mode_active, imuSample &imu_out,
+                     hrt_abstime timestamp)
+{
+    if (!ai_mode_active) {
+        state.reset();
+        return false;
+    }
+
+    if (!ensure_rx_socket(state, timestamp)) {
+        return false;
+    }
+
+    drain_rx_socket(state, timestamp);
+
+    if (!state.rx_queue.empty()) {
+        ImuPacket packet{};
+        memcpy(&packet, state.rx_queue.front().data(), sizeof(packet));
+        state.rx_queue.pop_front();
+
+        imuSample sample = packet_to_sample(packet);
+        state.last_ai_sample = sample;
+        state.last_ai_sample_valid = true;
+        imu_out = sample;
+        return true;
+    }
+
+    if (state.last_ai_sample_valid) {
+        if ((timestamp - state.rx_last_warning_log) > kWarningInterval) {
+            PX4_WARN("[IMU UDP RX] No new packets, re-using last AI sample");
+            state.rx_last_warning_log = timestamp;
+        }
+
+        imu_out = state.last_ai_sample;
+        return true;
+    }
+
+    if ((timestamp - state.rx_last_warning_log) > kWarningInterval) {
+        PX4_WARN("[IMU UDP RX] Awaiting first AI packet");
+        state.rx_last_warning_log = timestamp;
+    }
+
+    return false;
+}
+
+} // namespace ekf2::udp
+

--- a/src/modules/ekf2/ekf2_imu_udp_bridge.hpp
+++ b/src/modules/ekf2/ekf2_imu_udp_bridge.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <deque>
+#include <netinet/in.h>
+
+#include <drivers/drv_hrt.h>
+
+#include "EKF/common.h"
+
+namespace ekf2::udp
+{
+
+struct ImuUdpBridgeState {
+    int tx_socket{-1};
+    sockaddr_in tx_addr{};
+    uint32_t tx_count{0};
+    hrt_abstime tx_last_log{0};
+    hrt_abstime tx_last_error_log{0};
+
+    int rx_socket{-1};
+    sockaddr_in rx_addr{};
+    uint32_t rx_count{0};
+    hrt_abstime rx_last_log{0};
+    hrt_abstime rx_last_warning_log{0};
+
+    std::deque<std::array<uint8_t, 55>> tx_queue;
+    std::deque<std::array<uint8_t, 55>> rx_queue;
+
+    imuSample last_ai_sample{};
+    bool last_ai_sample_valid{false};
+    uint64_t last_rx_timestamp_sample{0};
+
+    ~ImuUdpBridgeState();
+
+    void reset();
+};
+
+bool PublishImuSample(ImuUdpBridgeState &state, bool ai_mode_active, const imuSample &imu,
+                      hrt_abstime timestamp, uint32_t accel_device_id, uint32_t gyro_device_id,
+                      uint8_t accel_calibration_count, uint8_t gyro_calibration_count);
+
+bool ConsumeAiSample(ImuUdpBridgeState &state, bool ai_mode_active, imuSample &imu_out,
+                     hrt_abstime timestamp);
+
+} // namespace ekf2::udp
+

--- a/src/modules/imu_ai_bridge/listen_ekf2_udp.py
+++ b/src/modules/imu_ai_bridge/listen_ekf2_udp.py
@@ -1,318 +1,322 @@
 #!/usr/bin/env python3
 """
-EKF2 IMU UDP Telemetry Listener
-================================
+EKF2 IMU UDP Telemetry Listener and Bridge
+==========================================
 
-This script listens to UDP telemetry from EKF2 module on port 14567 and displays
-the full vehicle_imu.msg data being processed by the estimator in AI mode.
+This utility forms the AI bridge between EKF2 and an external processor. It
+receives raw IMU data from EKF2 on port 14567, applies AI processing, and sends
+processed data back to EKF2 on port 14568. The bridge maintains bounded
+buffers on both ingress and egress paths to minimise packet loss and provide a
+stable flow of data.
 
-Usage:
-        ./listen_ekf2_udp.py              # Listen on port 14567 (default)
-        ./listen_ekf2_udp.py --port 14568 # Listen on custom port
+Features
+--------
+* High-capacity RX/TX queues with back-pressure logging
+* Non-blocking sockets with large kernel buffers (16 MB)
+* Deterministic processing loop with selector based polling
+* Timestamp monotonicity checks and packet integrity validation
+* Periodic statistics output including queue depths and drop counters
+* Optional verbose packet dump for diagnostics
 
-The script displays:
-    - Message count and timestamps
-    - Device IDs and calibration counters
-    - Delta velocity (m/s) - linear acceleration integrated over dt
-    - Delta angle (rad) - angular velocity integrated over dt
-    - Instantaneous acceleration (m/s²) and gyroscope (rad/s) rates
-    - Time deltas (us) - integration intervals
-    - Clipping flags
-    - Synchronized logging with EKF2
+Usage::
 
-Packet format: 55 bytes
-    - uint64_t timestamp (8 bytes)
-    - uint64_t timestamp_sample (8 bytes)
-    - uint32_t accel_device_id (4 bytes)
-    - uint32_t gyro_device_id (4 bytes)
-    - float delta_angle[3] (12 bytes)
-    - float delta_velocity[3] (12 bytes)
-    - uint16_t delta_angle_dt (2 bytes)
-    - uint16_t delta_velocity_dt (2 bytes)
-    - uint8_t delta_velocity_clipping (1 byte)
-    - uint8_t accel_calibration_count (1 byte)
-    - uint8_t gyro_calibration_count (1 byte)
+    ./listen_ekf2_udp.py [--port 14567] [--send-port 14568] [--bias 10.0]
 
-This helps verify that EKF2 is receiving and processing the correct AI IMU data, including all metadata.
 """
 
+import argparse
+import collections
+import selectors
 import socket
 import struct
 import sys
-import argparse
 import time
-from datetime import datetime
+from dataclasses import dataclass
+from typing import List
+
+IMU_PACKET_STRUCT = struct.Struct('<QQII6f2H3B')
+PACKET_SIZE = IMU_PACKET_STRUCT.size
+DEFAULT_RX_PORT = 14567
+DEFAULT_TX_PORT = 14568
+MAX_QUEUE_DEPTH = 512
+LOG_INTERVAL_S = 2.0
+WARNING_INTERVAL_S = 1.0
 
 
-def parse_imu_packet(data):
-    """Parse binary IMU packet from EKF2 UDP stream.
+@dataclass
+class ImuPacket:
+    """Structured representation of a 55-byte EKF2 IMU packet."""
 
-    Packet format (55 bytes):
-        uint64_t timestamp
-        uint64_t timestamp_sample
-        uint32_t accel_device_id
-        uint32_t gyro_device_id
-        float delta_angle[3]
-        float delta_velocity[3]
-        uint16_t delta_angle_dt
-        uint16_t delta_velocity_dt
-        uint8_t delta_velocity_clipping
-        uint8_t accel_calibration_count
-        uint8_t gyro_calibration_count
-        Total: 55 bytes
-    """
-    if len(data) < 55:
-        return None
+    timestamp: int
+    timestamp_sample: int
+    accel_device_id: int
+    gyro_device_id: int
+    delta_angle: tuple
+    delta_velocity: tuple
+    delta_angle_dt: int
+    delta_velocity_dt: int
+    delta_velocity_clipping: int
+    accel_calibration_count: int
+    gyro_calibration_count: int
 
-    try:
-        values = struct.unpack('<QQII6f2H3B', data[:55])
-        timestamp = values[0]
-        timestamp_sample = values[1]
-        accel_device_id = values[2]
-        gyro_device_id = values[3]
+    @classmethod
+    def from_bytes(cls, data: bytes) -> "ImuPacket":
+        if len(data) != PACKET_SIZE:
+            raise ValueError(f"Invalid packet size: {len(data)} bytes")
+
+        values = IMU_PACKET_STRUCT.unpack(data)
         delta_angle = values[4:7]
         delta_velocity = values[7:10]
-        delta_angle_dt = values[10]
-        delta_velocity_dt = values[11]
-        delta_velocity_clipping = values[12]
-        accel_calibration_count = values[13]
-        gyro_calibration_count = values[14]
+        return cls(
+            timestamp=values[0],
+            timestamp_sample=values[1],
+            accel_device_id=values[2],
+            gyro_device_id=values[3],
+            delta_angle=delta_angle,
+            delta_velocity=delta_velocity,
+            delta_angle_dt=values[10],
+            delta_velocity_dt=values[11],
+            delta_velocity_clipping=values[12],
+            accel_calibration_count=values[13],
+            gyro_calibration_count=values[14],
+        )
 
-        return {
-            'timestamp': timestamp,
-            'timestamp_sample': timestamp_sample,
-            'accel_device_id': accel_device_id,
-            'gyro_device_id': gyro_device_id,
-            'delta_angle': delta_angle,
-            'delta_velocity': delta_velocity,
-            'delta_angle_dt': delta_angle_dt,
-            'delta_velocity_dt': delta_velocity_dt,
-            'delta_velocity_clipping': delta_velocity_clipping,
-            'accel_calibration_count': accel_calibration_count,
-            'gyro_calibration_count': gyro_calibration_count,
-        }
-    except struct.error as e:
-        return None
-
-
-def convert_to_rates(pkt):
-    """Convert delta values to instantaneous acceleration and gyroscope rates.
-
-    Returns:
-        tuple: (accel_x, accel_y, accel_z, gyro_x, gyro_y, gyro_z)
-    """
-    dt_angle = pkt['delta_angle_dt'] / 1e6      # Convert us to seconds
-    dt_velocity = pkt['delta_velocity_dt'] / 1e6 # Convert us to seconds
-
-    # Divide by dt to get instantaneous rates
-    if dt_angle > 0:
-        gyro_x = pkt['delta_angle'][0] / dt_angle
-        gyro_y = pkt['delta_angle'][1] / dt_angle
-        gyro_z = pkt['delta_angle'][2] / dt_angle
-    else:
-        gyro_x = gyro_y = gyro_z = 0.0
-
-    if dt_velocity > 0:
-        accel_x = pkt['delta_velocity'][0] / dt_velocity
-        accel_y = pkt['delta_velocity'][1] / dt_velocity
-        accel_z = pkt['delta_velocity'][2] / dt_velocity
-    else:
-        accel_x = accel_y = accel_z = 0.0
-
-    return (accel_x, accel_y, accel_z, gyro_x, gyro_y, gyro_z)
+    def to_bytes(self) -> bytes:
+        return IMU_PACKET_STRUCT.pack(
+            self.timestamp,
+            self.timestamp_sample,
+            self.accel_device_id,
+            self.gyro_device_id,
+            *self.delta_angle,
+            *self.delta_velocity,
+            self.delta_angle_dt,
+            self.delta_velocity_dt,
+            self.delta_velocity_clipping,
+            self.accel_calibration_count,
+            self.gyro_calibration_count,
+        )
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description='Listen to EKF2 IMU UDP telemetry on port 14567'
-    )
-    parser.add_argument('--port', type=int, default=14567,
-                        help='UDP port to listen on (default: 14567)')
-    parser.add_argument('--verbose', '-v', action='store_true',
-                        help='Verbose output with every packet')
+class ImuAiBridge:
+    """Handles UDP reception, processing, and transmission of EKF2 IMU packets."""
 
-    args = parser.parse_args()
+    def __init__(self, listen_port: int, send_port: int, bias: float, verbose: bool) -> None:
+        self._listen_port = listen_port
+        self._send_port = send_port
+        self._bias = bias
+        self._verbose = verbose
 
-    # Create UDP socket for receiving on port 14567
-    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._selector = selectors.DefaultSelector()
+        self._rx_socket = self._create_socket()
+        self._tx_socket = self._create_socket()
+        self._configure_rx_socket()
+        self._configure_tx_socket()
 
-    # Increase socket receive buffer to avoid packet loss
-    try:
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 16 * 1024 * 1024)  # 16MB
-    except:
-        print("[WARNING] Could not set SO_RCVBUF to 16MB")
+        self._rx_queue: collections.deque[ImuPacket] = collections.deque(maxlen=MAX_QUEUE_DEPTH)
+        self._tx_queue: collections.deque[bytes] = collections.deque(maxlen=MAX_QUEUE_DEPTH)
 
-    # Create UDP socket for sending on port 14568
-    tx_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self._rx_count = 0
+        self._tx_count = 0
+        self._dropped_rx = 0
+        self._dropped_tx = 0
+        self._last_rx_timestamp = 0
 
-    # Increase socket send buffer to avoid packet loss
-    try:
-        tx_sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 16 * 1024 * 1024)  # 16MB
-    except:
-        print("[WARNING] Could not set SO_SNDBUF to 16MB")
+        self._last_log = time.monotonic()
+        self._last_warning = 0.0
+        self._running = False
 
-    tx_addr = ('127.0.0.1', 14568)
-    filtered_device_id = 0x14010c  # Primary IMU
+    @staticmethod
+    def _create_socket() -> socket.socket:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.setblocking(False)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        buffer_size = 16 * 1024 * 1024
+        for opt in (socket.SO_RCVBUF, socket.SO_SNDBUF):
+            try:
+                sock.setsockopt(socket.SOL_SOCKET, opt, buffer_size)
+            except OSError:
+                # Large buffers may not be honoured, continue with defaults
+                pass
+        return sock
 
-    try:
-        sock.bind(('127.0.0.1', args.port))
-        print(f"[EKF2 IMU UDP] Listening on 127.0.0.1:{args.port}")
-        print(f"[EKF2 IMU UDP] TX configured to send to 127.0.0.1:14568")
-        print(f"[EKF2 IMU UDP] Filtering to device ID: 0x{filtered_device_id:08x} (primary IMU)")
-        print(f"[EKF2 IMU UDP] Waiting for EKF2_IMU_SRC=1 (AI mode) telemetry...")
-        print()
+    def _configure_rx_socket(self) -> None:
+        self._rx_socket.bind(('127.0.0.1', self._listen_port))
+        self._selector.register(self._rx_socket, selectors.EVENT_READ)
+        print(f"[AI BRIDGE] Listening for EKF2 raw IMU on 127.0.0.1:{self._listen_port}")
 
-        msg_count = 0
-        tx_count = 0
-        tx_errors = 0
-        rx_errors = 0
-        filtered_out = 0
-        first_packet_logged = False
-        source_ids = set()
+    def _configure_tx_socket(self) -> None:
+        self._tx_addr = ('127.0.0.1', self._send_port)
+        print(f"[AI BRIDGE] Sending processed IMU to 127.0.0.1:{self._send_port}")
 
-        last_time = time.time()
-        rate_sum = 0.0
-        rate_count = 0
+    def close(self) -> None:
+        try:
+            self._selector.unregister(self._rx_socket)
+        except Exception:
+            pass
+        self._rx_socket.close()
+        self._tx_socket.close()
+        self._running = False
 
+    def _log_warning(self, message: str) -> None:
+        now = time.monotonic()
+        if now - self._last_warning >= WARNING_INTERVAL_S:
+            print(f"[WARN] {message}")
+            self._last_warning = now
+
+    def _receive_packets(self) -> None:
         while True:
             try:
-                data, addr = sock.recvfrom(1024)
-                pkt = parse_imu_packet(data)
-
-                if pkt is None:
-                    print(f"[!] Invalid packet: got {len(data)} bytes, expected 55")
-                    rx_errors += 1
-                    continue
-
-                msg_count += 1
-
-                # Track all sources
-                source_ids.add(pkt['accel_device_id'])
-
-                # Skip packets from other IMU sources
-                if pkt['accel_device_id'] != filtered_device_id:
-                    filtered_out += 1
-                    continue
-
-                # Log first packet received
-                if not first_packet_logged:
-                    first_time_ms = pkt['timestamp'] / 1000.0
-                    print(f"[STARTUP] PY: First packet received at [{first_time_ms:.1f}ms] | ts={pkt['timestamp']} us")
-                    first_packet_logged = True
-
-                # Calculate rate from delta_velocity_dt
-                dt_velocity = pkt['delta_velocity_dt'] / 1e6  # Convert to seconds
-                if dt_velocity > 0:
-                    packet_rate = 1.0 / dt_velocity
-                    rate_sum += packet_rate
-                    rate_count += 1
-
-                # Convert deltas to instantaneous rates
-                accel_x, accel_y, accel_z, gyro_x, gyro_y, gyro_z = convert_to_rates(pkt)
-
-                # Apply AI processing: add constant bias of +1.0 m/s² to linear acceleration
-                # This modifies the delta_velocity values in the packet
-                pkt_array = bytearray(data[:55])
-
-                # Reconstruct the packet with bias applied
-                # delta_velocity starts at offset 36 (timestamp(8) + timestamp_sample(8) +
-                # accel_device_id(4) + gyro_device_id(4) + delta_angle[3](12) = 36)
-                bias_accel = 10.0  # m/s² bias to add
-                dt_velocity_s = pkt['delta_velocity_dt'] / 1e6  # Convert to seconds
-
-                dv_offset = 36
-                if dt_velocity_s > 0:
-                    # Convert bias from acceleration to delta_velocity
-                    delta_velocity_bias = bias_accel * dt_velocity_s
-
-                    # Unpack delta_velocity values from packet
-                    dv_x, dv_y, dv_z = struct.unpack('<3f', pkt_array[dv_offset:dv_offset+12])
-
-                    # Add bias
-                    dv_x_biased = dv_x + delta_velocity_bias
-                    dv_y_biased = dv_y + delta_velocity_bias
-                    dv_z_biased = dv_z + delta_velocity_bias
-
-                    # Pack back into packet
-                    pkt_array[dv_offset:dv_offset+12] = struct.pack('<3f', dv_x_biased, dv_y_biased, dv_z_biased)
-
-                # Send back the modified 55-byte packet to EKF2 on port 14568
-                # (This is where you'd apply AI processing)
-                try:
-                    tx_result = tx_sock.sendto(bytes(pkt_array), tx_addr)
-                    if tx_result == 55:
-                        tx_count += 1
-                    else:
-                        print(f"[TX ERROR] sendto() returned {tx_result} bytes (expected 55)")
-                        tx_errors += 1
-                except Exception as e:
-                    print(f"[TX ERROR] {e}")
-                    tx_errors += 1
-
-                if args.verbose:
-                    # Print every packet in verbose mode
-                    timestamp_ms = pkt['timestamp'] / 1000.0
-                    print(f"[{timestamp_ms:.1f}ms] RX={msg_count} (Filtered out: {filtered_out}) | TX={tx_count} "
-                          f"| ACC=[{accel_x:.4f}, {accel_y:.4f}, {accel_z:.4f}] m/s² "
-                          f"| GYRO=[{gyro_x:.4f}, {gyro_y:.4f}, {gyro_z:.4f}] rad/s")
-
-                # Log summary: first packet and every 200th packet (matching EKF2 behavior)
-                if tx_count == 1 or (tx_count % 200 == 0 and tx_count > 0):
-                    current_time = time.time()
-                    elapsed = current_time - last_time
-                    avg_rate = (rate_sum / rate_count) if rate_count > 0 else 0.0
-                    loss_pct = 0.0
-
-                    timestamp_ms = pkt['timestamp'] / 1000.0
-                    sources_list = ", ".join([f"0x{id:08x}" for id in sorted(source_ids)])
-
-                    print(f"[{timestamp_ms:.1f}ms] PY RX={msg_count} (Filtered out: {filtered_out}) | TX={tx_count} "
-                          f"| Dropped=0 ({loss_pct:.1f}%) | Sources: {len(source_ids)} [{sources_list}] | "
-                          f"Rate: {avg_rate:.1f} Hz")
-                    print(f"  ACC=[{accel_x:.4f}, {accel_y:.4f}, {accel_z:.4f}] m/s² | "
-                          f"GYRO=[{gyro_x:.4f}, {gyro_y:.4f}, {gyro_z:.4f}] rad/s")
-
-                    # Print AI processing info (bias applied)
-                    if dt_velocity_s > 0:
-                        # Compute original ACC values (before bias)
-                        dv_x_orig, dv_y_orig, dv_z_orig = struct.unpack('<3f', data[dv_offset:dv_offset+12])
-                        acc_x_orig = dv_x_orig / dt_velocity_s
-                        acc_y_orig = dv_y_orig / dt_velocity_s
-                        acc_z_orig = dv_z_orig / dt_velocity_s
-
-                        # Compute biased ACC values (after bias)
-                        delta_velocity_bias = bias_accel * dt_velocity_s
-                        acc_x_biased = (dv_x_orig + delta_velocity_bias) / dt_velocity_s
-                        acc_y_biased = (dv_y_orig + delta_velocity_bias) / dt_velocity_s
-                        acc_z_biased = (dv_z_orig + delta_velocity_bias) / dt_velocity_s
-
-                        print(f"[AI PROC] +{bias_accel:.1f} m/s² bias applied | "
-                              f"acc_orig=[{acc_x_orig:.4f}, {acc_y_orig:.4f}, {acc_z_orig:.4f}] m/s² -> "
-                              f"acc_biased=[{acc_x_biased:.4f}, {acc_y_biased:.4f}, {acc_z_biased:.4f}] m/s²")
-
-                    last_time = current_time
-                    rate_sum = 0.0
-                    rate_count = 0
-
-            except struct.error as e:
-                print(f"[!] Parse error: {e}")
-                rx_errors += 1
-                continue
-            except KeyboardInterrupt:
+                data, _ = self._rx_socket.recvfrom(PACKET_SIZE)
+            except BlockingIOError:
+                break
+            except OSError as exc:
+                self._log_warning(f"RX socket error: {exc}")
                 break
 
-    except OSError as e:
-        print(f"[ERROR] Failed to bind to 127.0.0.1:{args.port}: {e}")
-        print(f"        Make sure port {args.port} is not already in use")
-        sys.exit(1)
-    finally:
-        sock.close()
-        tx_sock.close()
+            if len(data) != PACKET_SIZE:
+                self._dropped_rx += 1
+                self._log_warning(f"Discarded packet with unexpected size {len(data)} bytes")
+                continue
 
-    print(f"\n[EKF2 IMU UDP] Stopped. Total RX: {msg_count}, Filtered out: {filtered_out}, Total TX: {tx_count}, TX Errors: {tx_errors}, RX Errors: {rx_errors}")
+            try:
+                packet = ImuPacket.from_bytes(data)
+            except ValueError as exc:
+                self._dropped_rx += 1
+                self._log_warning(str(exc))
+                continue
+
+            if self._rx_queue.maxlen and len(self._rx_queue) == self._rx_queue.maxlen:
+                self._dropped_rx += 1
+                self._log_warning("RX queue full, dropping oldest packet")
+
+            self._rx_queue.append(packet)
+            self._rx_count += 1
+
+            if packet.timestamp_sample <= self._last_rx_timestamp and self._last_rx_timestamp != 0:
+                self._log_warning(
+                    f"Non-monotonic timestamp detected (new={packet.timestamp_sample} <= last={self._last_rx_timestamp})"
+                )
+
+            self._last_rx_timestamp = packet.timestamp_sample
+
+            if self._verbose:
+                print(f"[RX] ts={packet.timestamp_sample} us | dv={packet.delta_velocity} | da={packet.delta_angle}")
+
+    def _apply_ai_processing(self, packet: ImuPacket) -> ImuPacket:
+        if packet.delta_velocity_dt == 0:
+            return packet
+
+        dt_seconds = packet.delta_velocity_dt / 1e6
+        delta_bias = self._bias * dt_seconds
+        dv = tuple(axis + delta_bias for axis in packet.delta_velocity)
+        return ImuPacket(
+            timestamp=packet.timestamp,
+            timestamp_sample=packet.timestamp_sample,
+            accel_device_id=packet.accel_device_id,
+            gyro_device_id=packet.gyro_device_id,
+            delta_angle=packet.delta_angle,
+            delta_velocity=dv,
+            delta_angle_dt=packet.delta_angle_dt,
+            delta_velocity_dt=packet.delta_velocity_dt,
+            delta_velocity_clipping=packet.delta_velocity_clipping,
+            accel_calibration_count=packet.accel_calibration_count,
+            gyro_calibration_count=packet.gyro_calibration_count,
+        )
+
+    def _process_packets(self) -> None:
+        while self._rx_queue:
+            packet = self._rx_queue.popleft()
+            processed = self._apply_ai_processing(packet)
+            payload = processed.to_bytes()
+
+            if self._tx_queue.maxlen and len(self._tx_queue) == self._tx_queue.maxlen:
+                self._tx_queue.popleft()
+                self._dropped_tx += 1
+                self._log_warning("TX queue full, dropping oldest packet")
+
+            self._tx_queue.append(payload)
+
+    def _flush_tx(self) -> None:
+        while self._tx_queue:
+            payload = self._tx_queue[0]
+            try:
+                sent = self._tx_socket.sendto(payload, self._tx_addr)
+            except BlockingIOError:
+                break
+            except OSError as exc:
+                self._log_warning(f"TX socket error: {exc}")
+                self._tx_queue.popleft()
+                self._dropped_tx += 1
+                continue
+
+            if sent != PACKET_SIZE:
+                self._log_warning(f"Partial packet sent ({sent} of {PACKET_SIZE} bytes)")
+                self._tx_queue.popleft()
+                self._dropped_tx += 1
+                continue
+
+            self._tx_queue.popleft()
+            self._tx_count += 1
+
+            if self._verbose:
+                print(f"[TX] count={self._tx_count} | queue={len(self._tx_queue)}")
+
+    def _log_stats(self) -> None:
+        now = time.monotonic()
+        if now - self._last_log >= LOG_INTERVAL_S:
+            print(
+                f"[AI BRIDGE] RX={self._rx_count} (drop={self._dropped_rx}) | "
+                f"TX={self._tx_count} (drop={self._dropped_tx}) | "
+                f"queues: rx={len(self._rx_queue)}/{self._rx_queue.maxlen} tx={len(self._tx_queue)}/{self._tx_queue.maxlen}"
+            )
+            self._last_log = now
+
+    def run(self) -> None:
+        self._running = True
+        print("[AI BRIDGE] Bridge running. Press Ctrl+C to stop.")
+
+        try:
+            while self._running:
+                events = self._selector.select(timeout=0.01)
+                if events:
+                    self._receive_packets()
+                else:
+                    # Poll the RX socket to drain any lingering packets
+                    self._receive_packets()
+
+                self._process_packets()
+                self._flush_tx()
+                self._log_stats()
+        except KeyboardInterrupt:
+            print("\n[AI BRIDGE] Stopping bridge...")
+        finally:
+            self.close()
+            print(
+                f"[AI BRIDGE] Final stats -> RX={self._rx_count} (drop={self._dropped_rx}), "
+                f"TX={self._tx_count} (drop={self._dropped_tx})"
+            )
+
+
+def parse_args(argv: List[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="EKF2 IMU AI UDP bridge")
+    parser.add_argument('--port', type=int, default=DEFAULT_RX_PORT,
+                        help=f'UDP port to listen on (default: {DEFAULT_RX_PORT})')
+    parser.add_argument('--send-port', type=int, default=DEFAULT_TX_PORT,
+                        help=f'UDP port to send processed packets to (default: {DEFAULT_TX_PORT})')
+    parser.add_argument('--bias', type=float, default=10.0,
+                        help='Constant acceleration bias to apply during AI processing (m/s^2)')
+    parser.add_argument('--verbose', '-v', action='store_true', help='Print every packet as it is processed')
+    return parser.parse_args(argv)
+
+
+def main(argv: List[str]) -> int:
+    args = parse_args(argv)
+
+    bridge = ImuAiBridge(listen_port=args.port, send_port=args.send_port,
+                         bias=args.bias, verbose=args.verbose)
+    bridge.run()
+    return 0
 
 
 if __name__ == '__main__':
-    main()
-
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- factor the EKF2 AI IMU UDP publish/subscribe logic into dedicated bridge helpers with queueing and diagnostics
- update EKF2 to rely solely on AI-processed IMU samples when AI mode is active and to use the new bridge helpers
- overhaul the Python AI bridge to use bounded queues, selector-driven IO, and periodic health reporting to avoid packet loss

## Testing
- python3 -m py_compile src/modules/imu_ai_bridge/listen_ekf2_udp.py

------
https://chatgpt.com/codex/tasks/task_e_68f84aa1a19c832c9c78dc48773f4262